### PR TITLE
Call python instead of run in example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ This is a GUI variant of BIDS Dataset Description generator
 - PyQt5
 
 ### RUNNING THE PROJECT
-    run "main.py"
+    python main.py


### PR DESCRIPTION
I don't have a 'run' binary on my system, figure calling python directly may be more general.